### PR TITLE
Keep filtered dmenu empty states visible

### DIFF
--- a/Keystroke.qml
+++ b/Keystroke.qml
@@ -1194,7 +1194,8 @@ Item {
   readonly property int rowHeight: Style.space(compact ? 46 : 56)
   readonly property int rowSpacing: Style.space(3)
   readonly property int dmenuRowsHeight: {
-    var count = Math.max(1, resultModel.count)
+    // The empty state is a glyph plus a label, so one row clips it.
+    var count = resultModel.count || 2
     var maxRows = root.dmenuMaxHeight > 0 ? Math.max(1, Math.floor(Style.space(root.dmenuMaxHeight) / (rowHeight + rowSpacing))) : 12
     return Math.min(count, maxRows) * (rowHeight + rowSpacing)
   }
@@ -1550,6 +1551,7 @@ Item {
             foreground: root.foreground
         }
         Column {
+          id: emptyState
           visible: root.rows.length === 0 && root.mode !== "input" && (!root.pending || root.showLoading)
           anchors.centerIn: parent
           spacing: Style.space(12)

--- a/bin/keystroke
+++ b/bin/keystroke
@@ -79,6 +79,7 @@ case "${1:-help}" in
     python3 "$ROOT/tests/matching_session_check.py"
     python3 "$ROOT/tests/palette_matching_check.py"
     python3 "$ROOT/tests/palette_shortcut_check.py"
+    python3 "$ROOT/tests/palette_dmenu_check.py"
     python3 "$ROOT/tests/palette_route_check.py"
     python3 "$ROOT/tests/palette_motion_check.py"
     uv run --with-requirements "$ROOT/matching/requirements.lock" python "$ROOT/tests/matching_worker_check.py"

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,5 +1,23 @@
 > Historical checkpoints below include retired local-model and forked-Voxtype implementations. Current build: [Codex integration verification](codex-integration-verification.md).
 
+## Dmenu empty-state height (2026-09-10)
+
+- Reproduced from Omarchy's Keybindings picker with a query that matched no
+  rows. Dmenu sizing reserved one 49 px result row at zero results, while the
+  empty state's glyph, spacing and message needed 76 px; the card collapsed
+  around the shorter viewport and clipped “No matches for …” at its bottom.
+- A zero-result select picker now reserves two row slots for that empty state.
+  A picker with one real row remains one row tall, and the caller's
+  `maxHeight` continues to cap the result area.
+- `tests/palette_dmenu_check.py` drives the real palette offscreen with the
+  Keybindings payload and filters its only option away. Its viewport-fit
+  assertion fails on the `dev` baseline (`49 >= 76`) and passes on this tree;
+  it also verifies that only the empty picker grows. Full `bin/keystroke test`
+  passes: 162 QML tests and all integration checks, including the new dmenu
+  check. `bin/keystroke validate` passes and qmllint reports only existing
+  metadata warnings. An offscreen after-image was rendered and reviewed; the
+  patched plugin was not installed over the user's release copy.
+
 ## Release 1.4.1 (2026-09-11)
 
 - Documentation only: `site/guide/index.html` copy pass (32 replacements:

--- a/tests/palette_dmenu_check.py
+++ b/tests/palette_dmenu_check.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Dmenu sizing on the real palette keeps its empty state visible."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+root = Path(__file__).resolve().parents[1]
+with tempfile.TemporaryDirectory(prefix="keystroke-palette-dmenu-") as temp:
+    work = Path(temp)
+    project = work / "project"
+    shutil.copytree(root, project, ignore=shutil.ignore_patterns(".git", ".claude", ".agents", ".codex", "tests", "__pycache__"))
+    (work / "qs").symlink_to("/usr/share/omarchy/shell")
+    source = project / "Keystroke.qml"
+    qml = source.read_text()
+    qml = qml.replace("  id: root\n", "  id: root\n  property alias testCard: card\n  property alias testContent: content\n  property alias testEmptyState: emptyState\n", 1)
+    qml = qml.replace("  PanelWindow {", "  Window {\n    transientParent: null\n    width: 1000; height: 800")
+    qml = qml.replace("    anchors { top: true; bottom: true; left: true; right: true }\n", "")
+    source.write_text("\n".join(line for line in qml.splitlines() if "exclusionMode:" not in line and "WlrLayershell." not in line))
+    (work / "shell.qml").write_text('''import QtQuick
+import Quickshell
+import "project"
+ShellRoot {
+  id: test
+  property real oneRowHeight: 0
+  function check(ok, msg) { if (!ok) { console.log("FAIL", msg); Qt.quit(); throw Error(msg) } }
+  Keystroke { id: palette; omarchyPath: "/usr/share/omarchy" }
+  Timer { interval: 250; running: true; onTriggered: {
+    palette.open(JSON.stringify({ mode: "select", prompt: "Keybindings", options: ["Super + K → Keybindings"], width: 800, maxHeight: 500 }))
+    test.check(palette.rows.length === 1, "the picker begins with one row")
+    test.oneRowHeight = palette.testCard.height
+    palette.setQuery("tiltet")
+    palette.runQuery()
+    Qt.callLater(function() {
+      test.check(palette.rows.length === 0, "the filter has no matches")
+      test.check(palette.testContent.height >= palette.testEmptyState.implicitHeight,
+                 "the empty message fits: " + palette.testContent.height + " >= " + palette.testEmptyState.implicitHeight)
+      test.check(palette.testCard.height > test.oneRowHeight, "the empty picker reserves more room than one result row")
+      palette.cancel()
+      console.log("PASS palette dmenu")
+      Qt.quit()
+    })
+  } }
+  Timer { interval: 8000; running: true; onTriggered: { console.log("FAIL timeout"); Qt.quit() } }
+}
+''')
+    env = dict(os.environ, HOME=str(work), XDG_RUNTIME_DIR=str(work), QT_QPA_PLATFORM="offscreen", QT_QPA_PLATFORMTHEME="generic", QT_QUICK_BACKEND="software", QML_IMPORT_PATH=str(work))
+    env.pop("DISPLAY", None)
+    env.pop("WAYLAND_DISPLAY", None)
+    result = subprocess.run(["quickshell", "-p", str(work / "shell.qml")], env=env, capture_output=True, text=True, timeout=15)
+    output = result.stdout + result.stderr
+    assert "PASS palette dmenu" in output and "FAIL" not in output, output
+    assert "TypeError" not in output and "ReferenceError" not in output, output
+    print("PASS palette dmenu: an empty filtered picker keeps its message visible")


### PR DESCRIPTION
## Summary

- keep the shared dmenu empty state fully visible after a filter removes every row
- reserve two row slots only for zero-result select pickers; one-row pickers remain compact
- add an offscreen regression using the real Keybindings picker payload

## Root cause

The Keybindings command opens Keystroke through the dmenu-compatible `select` protocol with `width: 800` and `maxHeight: 500`. When a query matches no options, `dmenuRowsHeight` previously forced `resultModel.count` to a minimum of one row.

On the reproduced compact layout:

- available content height: 49 logical pixels
- empty-state implicit height: 76 logical pixels

The empty state contains a 40px glyph, spacing, and the “No matches for …” label. Centering that 76px column in a clipped 49px viewport cuts off the label and makes the picker appear to collapse.

## Fix

Use two row slots only when the result model is empty. Existing result counts and the caller's `maxHeight` cap keep their current behavior.

## Screenshots

**Before — message clipped after filtering Keybindings**

![Collapsed Keybindings picker with its no-matches message clipped](https://raw.githubusercontent.com/andrew-t-james-wc/keystroke/pr-dmenu-assets/screenshots/dmenu-empty-state-before.png)

**After — complete empty state visible**

![Keybindings picker with the complete no-matches message visible](https://raw.githubusercontent.com/andrew-t-james-wc/keystroke/pr-dmenu-assets/screenshots/dmenu-empty-state-after.png)

## Verification

- `tests/palette_dmenu_check.py` fails against the `dev` baseline with `49 >= 76` and passes with this change.
- `bin/keystroke validate`
- `bin/keystroke test` — 162 QML tests and all integration checks passed.
- `python3 site/check.py`
- `node --check site/script.js`
- `git diff --check`

The after-image was rendered from the real QML card offscreen. The patched plugin was not installed over the user's release copy.
